### PR TITLE
Address SDK conflict with legacy firebase-element

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.2.0",
-    "firebase": "https://www.gstatic.com/firebasejs/3.0.0/firebase.js",
+    "firebase-sdk": "https://www.gstatic.com/firebasejs/3.0.0/firebase.js",
     "app-storage": "polymerelements/app-storage#~0.9.0"
   },
   "devDependencies": {

--- a/firebase.html
+++ b/firebase.html
@@ -6,5 +6,4 @@ license that can be found in the LICENSE file or at
 https://github.com/firebase/polymerfire/blob/master/LICENSE
 -->
 
-<!-- TODO: Fix this script include when 3.0.0 is released: -->
-<script src="../firebase/index.js"></script>
+<script src="../firebase-sdk/index.js"></script>


### PR DESCRIPTION
/cc @mbleigh @rictic @e111077 

We need to make this change to address a naming conflict with the old SDK when deployed alongside the legacy firebase-element component.