### PR TITLE
Fix reference to element "auth" property

### DIFF
--- a/firebase-auth.html
+++ b/firebase-auth.html
@@ -192,7 +192,7 @@ defined as the default provider.
           if (!provider) {
             return Promise.reject('Must supply a provider for popup sign in.');
           }
-          if (!auth) {
+          if (!this.auth) {
             return Promise.reject('No app configured for firebase-auth!');
           }
 


### PR DESCRIPTION
Code refers to global "auth" variable instead of firebase-auth's "this.auth" property.