### PR TITLE
Fixed firebase-auth tests and issue with promises always resolving to then

### DIFF
--- a/firebase-auth.html
+++ b/firebase-auth.html
@@ -212,6 +212,7 @@ defined as the default provider.
         _handleSignIn: function(promise) {
           return promise.catch(function(err) {
             this.fire('error', err);
+            throw err;
           }.bind(this));
         },
 

--- a/test/firebase-auth.html
+++ b/test/firebase-auth.html
@@ -52,8 +52,6 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
         test('eventually signs in', function() {
           return authElement.signInAnonymously().then(function(user) {
             expect(user.uid).to.be.ok;
-          }).catch(function() {
-            throw 'Sign in Anonymously should not have failed';
           });
         });
 

--- a/test/firebase-auth.html
+++ b/test/firebase-auth.html
@@ -50,8 +50,18 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
         });
 
         test('eventually signs in', function() {
-          return authElement.signInAnonymously().then(function() {
-            expect(authElement.user).to.be.ok;
+          return authElement.signInAnonymously().then(function(user) {
+            expect(user.uid).to.be.ok;
+          }).catch(function() {
+            throw 'Sign in Anonymously should not have failed';
+          });
+        });
+
+        test('failed promises should be forwarded', function() {
+          return authElement.signInWithEmailAndPassword('', '').then(function(user) {
+            throw 'sign in with email and password should not have succeeded';
+          }).catch(function(err) {
+            expect(err).to.be.ok;
           });
         });
       });


### PR DESCRIPTION
Fixes #13

@cdata I noticed that authElement.user doesn't get set right away. I'm guessing this is due to it waiting for `__authChanged` to fire.