### PR TITLE
Fixed wrong dom-repeat template example in the firebase-query element

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Example usage:
     data="{{data}}">
 </firebase-query>
 
-<template is="dom-repeat" items="{{data}}" as="{{note}}">
+<template is="dom-repeat" items="{{data}}" as="note">
   <sticky-note note-data="{{note}}"></sticky-note>
 </template>
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Example usage:
     data="{{data}}">
 </firebase-query>
 
-<template is="dom-repeat" items="{{data}}" as="note">
+<template is="dom-repeat" items="{{data}}" as="{{note}}">
   <sticky-note note-data="{{note}}"></sticky-note>
 </template>
 

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -25,7 +25,7 @@ Example usage:
     data="{{data}}">
 </firebase-query>
 
-<template is="dom-repeat" items="{{data}}" as="{{note}}">
+<template is="dom-repeat" items="{{data}}" as="note">
   <sticky-note note-data="{{note}}"></sticky-note>
 </template>
 


### PR DESCRIPTION
The dom-repeat template examples were wrong, as they passed a value in curly brackets to the "as" attribute.