### PR TITLE
Reject fetching of stored value if ref is invalid

### DIFF
--- a/firebase-document.html
+++ b/firebase-document.html
@@ -157,6 +157,11 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
      */
     getStoredValue: function(path) {
       return new Promise(function(resolve, reject) {
+          if(this.ref.root.key == null) {
+            reject();
+            return;
+          }
+
           this.ref.child(path).once('value', function(snapshot) {
             var value = snapshot.val();
             if (value == null) {


### PR DESCRIPTION
For some reason `ref` sometimes is invalid when this gets called.
This caused the data attribute to be empty in some cases.
My fix is to disable fetching with an invalid ref.

Fix/workaround for #18