### PR TITLE
Add @polymerBehavior tags for docs and linting

### DIFF
--- a/firebase-common-behavior.html
+++ b/firebase-common-behavior.html
@@ -13,6 +13,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
   (function() {
     'use strict';
 
+    /** @polymerBehavior Polymer.FirebaseCommonBehavior */
     Polymer.FirebaseCommonBehaviorImpl = {
       properties: {
         app: {
@@ -54,6 +55,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
       }
     };
 
+    /** @polymerBehavior */
     Polymer.FirebaseCommonBehavior = [
       Polymer.AppNetworkStatusBehavior,
       Polymer.FirebaseCommonBehaviorImpl

--- a/firebase-database-behavior.html
+++ b/firebase-database-behavior.html
@@ -14,6 +14,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
   (function() {
     'use strict';
 
+    /** @polymerBehavior Polymer.FirebaseDatabaseBehavior */
     Polymer.FirebaseDatabaseBehaviorImpl = {
       properties: {
         db: {
@@ -92,6 +93,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
       }
     };
 
+    /** @polymerBehavior */
     Polymer.FirebaseDatabaseBehavior = [
       Polymer.AppStorageBehavior,
       Polymer.FirebaseCommonBehavior,


### PR DESCRIPTION
Following the [style guide](http://polymerelements.github.io/style-guide/#behaviors) this will make sure that properties and functions defined in the behaviors can be found by iron-component-page/hydrolysis and the polymer linter.

Fixes #31 and #47 