### PR TITLE
remove only this instance's listeners on detach

### DIFF
--- a/firebase-document.html
+++ b/firebase-document.html
@@ -45,7 +45,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
 
     detached: function() {
       if (this.ref) {
-        this.ref.off();
+        this.ref.off('value', this.__onFirebaseValue, this);
       }
     },
 


### PR DESCRIPTION
Fixes #38.

Instead of removing _all_ event listeners, we remove only this instance's listeners.