### PR TITLE
fix to enable storage access: added optional storageBucket parameter

### DIFF
--- a/firebase-app.html
+++ b/firebase-app.html
@@ -69,23 +69,41 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
           },
 
           /**
+           * The URL of your Firebase Storage Bucket. You can find this
+           * URL in the Storage panel of the Firebase Console.
+           * Available on the Firebase Console.
+           *
+           * For example: 'project-8118936357639140789.appspot.com'
+           */
+          storageBucket: {
+            type: String,
+            value: ''
+          },
+
+          /**
            * The Firebase app object constructed from the other fields of
            * this element.
            */
           app: {
             type: Object,
             notify: true,
-            computed: '__computeApp(name, apiKey, authDomain, databaseUrl)'
+            computed: '__computeApp(name, apiKey, authDomain, storageBucket, databaseUrl)'
           }
         },
 
-        __computeApp: function(name, apiKey, authDomain, databaseUrl) {
+        __computeApp: function(name, apiKey, authDomain, storageBucket, databaseUrl) {
           if (apiKey && authDomain && databaseUrl) {
-            var init = [{
+            var options = {
               apiKey: apiKey,
               authDomain: authDomain,
               databaseURL: databaseUrl
-            }];
+            };
+
+            if (storageBucket) {
+              options.storageBucket = storageBucket;
+            }
+
+            var init = [options];
 
             if (name) {
               init.push(name);


### PR DESCRIPTION
Using firebase-app to initialize firebase forces configuration without a storage bucket. The only change here is an added parameter 'storageBucket' created in the same manner as 'name' and included in the __createApp observer to incorporate into the call to initializeApp options.

Within __createApp the parameter is handled the same way as name, this required options to be built into a variable enabling storageBucket to be added if available.