### PR TITLE
apply removed sub-children on child changed

### DIFF
--- a/firebase-query.html
+++ b/firebase-query.html
@@ -314,14 +314,14 @@ Polymer({
 
         __onFirebaseChildChanged: function(snapshot) {
           var key = snapshot.key;
-          var value = this.__map[key];
+          var prev = this.__map[key];
 
-          this._log('Firebase child_changed:', key, value);
+          this._log('Firebase child_changed:', key, prev);
 
-          if (value) {
+          if (prev) {
             this.async(function() {
               var index = this.__indexFromKey(key);
-              value = snapshot.val();
+              var value = snapshot.val();
               value.$key = key;
               this.__map[key] = value;
 
@@ -331,6 +331,11 @@ Polymer({
                 if (value instanceof Object) {
                   for (var property in value) {
                     this.set(['data', index, property], value[property]);
+                  }
+                  for (var property in prev) {
+                    if(!value.hasOwnProperty(property)) {
+                      this.set(['data', index, property], undefined);
+                    }
                   }
                 } else {
                   this.set(['data', index], value);

--- a/test/firebase-query.html
+++ b/test/firebase-query.html
@@ -189,6 +189,19 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
                 query.path + '/' + query.data[0].$key, query.data[0]);
           });
         });
+
+        test('removes sub-properties as they are removed from children', function() {
+          var object = makeObject();
+          object.foo = true;
+
+          return pushFirebaseValue(query.path, object).then(function() {
+            expect(query.data[0].foo).to.be.eql(true);
+            return setFirebaseValue(
+                query.path + '/' + query.data[0].$key + '/foo', null);
+          }).then(function() {
+            expect(query.data[0].foo).to.be.eql(undefined);
+          });
+        });
       });
 
       suite('coordinating with dom-repeat', function() {


### PR DESCRIPTION
Fixes (part of) #43.

When a sub-property was removed remotely, we weren't applying the change locally and were rather just adding new/existing properties only.