### PR TITLE
Only remove instance-specific listeners.

### DIFF
--- a/firebase-database-behavior.html
+++ b/firebase-database-behavior.html
@@ -69,10 +69,6 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
       },
 
       __computeRef: function(db, path) {
-        if (this.ref) {
-          this.ref.off();
-        }
-
         if (db == null ||
             path == null ||
             !this.__pathReady(path) ||

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -151,7 +151,7 @@ Polymer({
             return;
           }
 
-          this.query.off();
+          this.__queryChanged(null, this.query);
         },
 
         child: function(key) {
@@ -261,7 +261,11 @@ Polymer({
 
         __queryChanged: function(query, oldQuery) {
           if (oldQuery) {
-            oldQuery.off();
+            oldQuery.off('child_added', this.__onFirebaseChildAdded, this);
+            oldQuery.off('child_removed', this.__onFirebaseChildRemoved, this);
+            oldQuery.off('child_changed', this.__onFirebaseChildChanged, this);
+            oldQuery.off('child_moved', this.__onFirebaseChildMoved, this);
+
             this.syncToMemory(function() {
               this.set('data', this.zeroValue);
             });

--- a/test/firebase-query.html
+++ b/test/firebase-query.html
@@ -42,6 +42,13 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
     </template>
   </test-fixture>
 
+  <test-fixture id="TwoQueries">
+    <template>
+      <firebase-query app-name="test"></firebase-query>
+      <firebase-query app-name="test"></firebase-query>
+    </template>
+  </test-fixture>
+
   <script>
     function expectFirebasePathValueToEql(path, value) {
       return getFirebaseValue(path).then(function(fbValue) {
@@ -224,6 +231,51 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
           }).then(function() {
             expect(query.data[0].$key).to.be.eql('b');
             expect(query.data.length).to.be.eql(2);
+          });
+        });
+      });
+
+      suite('instance isolation', function() {
+        var queryOne;
+        var queryTwo;
+        var path;
+
+        setup(function() {
+          var queries = fixture('TwoQueries');
+
+          path = root + '/common';
+
+          queryOne = queries[0];
+          queryTwo = queries[1];
+
+          queryOne.path = path;
+          queryTwo.path = path;
+
+          return pushFirebaseValue(path, {
+            value: 'initial'
+          });
+        });
+
+        teardown(function() {
+          return clearFirebaseValue(path);
+        });
+
+        test('queries have the same initial value', function() {
+          expect(queryOne.data.length).to.be.equal(1);
+          expect(queryTwo.data.length).to.be.equal(1);
+          expect(queryOne.data[0].value).to.be.equal(queryTwo.data[0].value);
+        });
+
+        suite('removing one instance from the DOM', function() {
+          test('preserves listeners on the remaining instance', function() {
+            queryOne.parentNode.removeChild(queryOne);
+
+            return pushFirebaseValue(path, {
+              value: 'new'
+            }).then(function() {
+              expect(queryOne.data.length).to.be.equal(0);
+              expect(queryTwo.data.length).to.be.equal(2);
+            });
           });
         });
       });


### PR DESCRIPTION
I ended up siding with a design where we just manually remove listeners in implementations that add them. Since listeners may be added to `ref`, or may be added to `query`, and since listeners require the name of the event in addition to the relevant callback to be removed, there didn't seem to be a good opportunity to generalize this cleanup.

Fixes #106 