### PR TITLE
Firebase Query ordering respects prev child key.

### DIFF
--- a/firebase-query.html
+++ b/firebase-query.html
@@ -280,24 +280,27 @@ Polymer({
         },
 
         __indexFromKey: function(key) {
-          for (var i = 0; i < this.data.length; i++) {
-            if (this.data[i].$key === key) {
-              return i;
+          if (key != null) {
+            for (var i = 0; i < this.data.length; i++) {
+              if (this.data[i].$key === key) {
+                return i;
+              }
             }
           }
           return -1;
         },
 
-        __onFirebaseChildAdded: function(snapshot) {
+        __onFirebaseChildAdded: function(snapshot, previousChildKey) {
           var value = snapshot.val();
           var key = snapshot.key;
+          var previousChildIndex = this.__indexFromKey(previousChildKey);
 
           this._log('Firebase child_added:', key, value);
 
           value.$key = key;
 
           this.__map[key] = value;
-          this.push('data', value);
+          this.splice('data', previousChildIndex + 1, 0, value);
         },
 
         __onFirebaseChildRemoved: function(snapshot) {

--- a/test/firebase-query.html
+++ b/test/firebase-query.html
@@ -29,7 +29,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
 
   <test-fixture id="BasicQuery">
     <template>
-      <firebase-query app-name="test" log></firebase-query>
+      <firebase-query app-name="test"></firebase-query>
     </template>
   </test-fixture>
 
@@ -127,6 +127,26 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
             query.data.forEach(function(value, index) {
               expect(value.val).to.be.equal(values[index].val);
             });
+          });
+        });
+
+        test('correctly orders newly added items', function() {
+          var values = [makeObject(1), makeObject(3)];
+          query.orderByChild = 'val';
+          return setFirebaseValue(query.path, values).then(function() {
+
+            query.data.forEach(function(value, index) {
+              expect(value.val).to.be.equal(values[index].val);
+            });
+
+            values.splice(1, 0, makeObject(2));
+
+            return setFirebaseValue(query.path + '/2', values[1])
+                .then(function() {
+                  query.data.forEach(function(value, index) {
+                    expect(value.val).to.be.equal(values[index].val);
+                  });
+                });
           });
         });
       });


### PR DESCRIPTION
Firebase Query was accidentally ignoring the second parameter to the
child_added event listener, causing newly added items (after the first
batch of add events) to be added in the wrong order.

/cc @notwaldorf