### PR TITLE
Typo Sample Javascript for catch error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ attempt authentication, e.g.:
 
 ```javascript
 this.$.auth.signInWithPopup()
-    .then(function(response) {// successful authentication response here})
-    .catch(function(error) {// unsuccessful authentication response here});
+    .then(function(response){
+           // successful authentication response here"
+        }, function(error){
+           // unsuccessful authentication response here
+     });
 ```
 
 This popup sign-in will then attempt to sign in using Google as an OAuth


### PR DESCRIPTION
Hi! 

When using .catch was returning:
Uncaught TypeError: this.$.auth.signInWithPopup(...).then(...).cacth is not a function

According to MDN(Mozilla Developer Network): The *then()* method returns a Promise. It takes two arguments: callback functions for the *success* and *failure* cases of the Promise.
[Promise …then](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise/then)

Thanks for all!