### PR TITLE
Splits imports up per-feature.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.2",
-    "firebase": "^3.5",
+    "firebase": ">= 3.5.1 < 4.0",
     "app-storage": "polymerelements/app-storage#^0.9.0"
   },
   "devDependencies": {

--- a/firebase-app-script.html
+++ b/firebase-app-script.html
@@ -1,0 +1,1 @@
+<script src="../firebase/firebase-app.js"></script>

--- a/firebase-app.html
+++ b/firebase-app.html
@@ -7,7 +7,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="firebase.html">
+<link rel="import" href="firebase-app-script.html">
 <dom-module id="firebase-app">
   <script>
     (function() {

--- a/firebase-auth-script.html
+++ b/firebase-auth-script.html
@@ -1,0 +1,1 @@
+<script src="../firebase/firebase-auth.js"></script>

--- a/firebase-auth.html
+++ b/firebase-auth.html
@@ -7,8 +7,8 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="firebase.html">
 <link rel="import" href="firebase-common-behavior.html">
+<link rel="import" href="firebase-auth-script.html">
 
 <!--
 `firebase-auth` is a wrapper around the Firebase authentication API. It notifies

--- a/firebase-common-behavior.html
+++ b/firebase-common-behavior.html
@@ -8,7 +8,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../app-storage/app-network-status-behavior.html">
-<link rel="import" href="firebase.html">
+<link rel="import" href="firebase-app-script.html">
 <script>
   (function() {
     'use strict';

--- a/firebase-database-behavior.html
+++ b/firebase-database-behavior.html
@@ -9,7 +9,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../app-storage/app-storage-behavior.html">
 <link rel="import" href="firebase-common-behavior.html">
-<link rel="import" href="firebase.html">
+<link rel="import" href="firebase-database-script.html">
 <script>
   (function() {
     'use strict';

--- a/firebase-database-script.html
+++ b/firebase-database-script.html
@@ -1,0 +1,1 @@
+<script src="../firebase/firebase-database.js"></script>

--- a/firebase-document.html
+++ b/firebase-document.html
@@ -8,7 +8,6 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="firebase-database-behavior.html">
-<link rel="import" href="firebase.html">
 <script>
   'use strict';
 

--- a/firebase-messaging-script.html
+++ b/firebase-messaging-script.html
@@ -1,0 +1,1 @@
+<script src="../firebase/firebase-messaging.js"></script>

--- a/firebase-messaging.html
+++ b/firebase-messaging.html
@@ -7,8 +7,8 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="firebase.html">
 <link rel="import" href="firebase-common-behavior.html">
+<link rel="import" href="firebase-messaging-script.html">
 
 <!--
 `firebase-messaging` is a wrapper around the Firebase Cloud Messaging API. It

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -8,7 +8,6 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="firebase-database-behavior.html">
-<link rel="import" href="firebase.html">
 
 
 <!--

--- a/firebase-storage-script.html
+++ b/firebase-storage-script.html
@@ -1,0 +1,1 @@
+<script src="../firebase/firebase-storage.js"></script>

--- a/firebase.html
+++ b/firebase.html
@@ -6,4 +6,8 @@ license that can be found in the LICENSE file or at
 https://github.com/firebase/polymerfire/blob/master/LICENSE
 -->
 
-<script src="../firebase/firebase.js"></script>
+<link rel="import" href="firebase-app-script.html">
+<link rel="import" href="firebase-auth-script.html">
+<link rel="import" href="firebase-database-script.html">
+<link rel="import" href="firebase-messaging-script.html">
+<link rel="import" href="firebase-storage-script.html">

--- a/test/firebase-common-behavior.html
+++ b/test/firebase-common-behavior.html
@@ -17,7 +17,6 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../app-storage/test/app-storage-compatibility-suite.html">
-  <link rel="import" href="../firebase.html">
   <link rel="import" href="../firebase-common-behavior.html">
   <link rel="import" href="../firebase-app.html">
 </head>

--- a/test/firebase-database-behavior.html
+++ b/test/firebase-database-behavior.html
@@ -17,7 +17,6 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../app-storage/test/app-storage-compatibility-suite.html">
-  <link rel="import" href="../firebase.html">
   <link rel="import" href="../firebase-database-behavior.html">
   <link rel="import" href="../firebase-app.html">
 </head>

--- a/test/firebase-document.html
+++ b/test/firebase-document.html
@@ -17,7 +17,6 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" href="../../app-storage/test/app-storage-compatibility-suite.html">
-  <link rel="import" href="../firebase.html">
   <link rel="import" href="../firebase-app.html">
   <link rel="import" href="../firebase-document.html">
 </head>


### PR DESCRIPTION
With Firebase v3..5.1, individual JS files are now available in the Bower distribution for `firebase-{app,auth,database,messaging,storage}`.

This PR prefers using those pieces individually to encourage and enable developers to lazy-load individual components, making PolymerFire more PRPL-Compatible.

/cc @slightlyoff