### PR TITLE
solve 0 key see as no key

### DIFF
--- a/firebase-document.html
+++ b/firebase-document.html
@@ -86,7 +86,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
           reject(new Error('No app configured!'));
         }
 
-        if (key) {
+        if (key !== undefined) {
           path = parentPath + '/' + key;
           resolve(this._setFirebaseValue(path, this.data));
         } else {


### PR DESCRIPTION
Actualy when a key is set to 0, the firebase-document think that there is no key, but firebase can self generate key at 0 from array, and the concerned item will be untouchable.