### PR TITLE
Lazily await app initializing when necessary.

### DIFF
--- a/firebase-app.html
+++ b/firebase-app.html
@@ -121,6 +121,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
             }
 
             firebase.initializeApp.apply(firebase, init);
+            this.fire('firebase-app-initialized');
           } else {
             return null;
           }

--- a/firebase-common-behavior.html
+++ b/firebase-common-behavior.html
@@ -43,6 +43,13 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
           }
         } catch (e) {
           // appropriate app hasn't been initialized yet
+          var self = this;
+          window.addEventListener('firebase-app-initialized',
+              function onFirebaseAppInitialized(event) {
+                window.removeEventListener(
+                    'firebase-app-initialized', onFirebaseAppInitialized);
+                self.__appNameChanged(self.appName);
+              });
         }
       },
 


### PR DESCRIPTION
With the new order of element intialization (bottom-up), the
firebase-app element is typically the last one to be initialized. This
means that Polymerfire elements need to await app initialization in
order to successfully create app instances for themselves.