### PR TITLE
Fix change path on firebase-query issue 

### DIFF
--- a/firebase-query.html
+++ b/firebase-query.html
@@ -283,7 +283,7 @@ Polymer({
         __pathChanged: function(path, oldPath) {
           // we only need to reset the data if the path is null (will also trigged when this element initiates)
           // When path changes and is not null, it triggers a ref change (via __computeRef(db,path)), which then triggers a __queryChanged setting data to zeroValue
-          
+
           if (path == null ) {
             this.syncToMemory(function() {
               this.data = this.zeroValue;
@@ -298,13 +298,8 @@ Polymer({
             oldQuery.off('child_changed', this.__onFirebaseChildChanged, this);
             oldQuery.off('child_moved', this.__onFirebaseChildMoved, this);
 
-            this.__queryIsChanging= true;  
-            
-            console.info('SYNC QUERY 00');
             this.syncToMemory(function() {
-              console.info('SYNC QUERY 11');
               this.set('data', this.zeroValue);
-              this.__queryIsChanging = false;
             });
           }
 

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -276,6 +276,21 @@ Polymer({
           return query;
         },
 
+        /**
+         * `@override`
+         */
+
+        __pathChanged: function(path, oldPath) {
+          // we only need to reset the data if the path is null (will also trigged when this element initiates)
+          // When path changes and is not null, it triggers a ref change (via __computeRef(db,path)), which then triggers a __queryChanged setting data to zeroValue
+          
+          if (path == null ) {
+            this.syncToMemory(function() {
+              this.data = this.zeroValue;
+            });
+          }
+        },
+
         __queryChanged: function(query, oldQuery) {
           if (oldQuery) {
             oldQuery.off('child_added', this.__onFirebaseChildAdded, this);
@@ -283,8 +298,13 @@ Polymer({
             oldQuery.off('child_changed', this.__onFirebaseChildChanged, this);
             oldQuery.off('child_moved', this.__onFirebaseChildMoved, this);
 
+            this.__queryIsChanging= true;  
+            
+            console.info('SYNC QUERY 00');
             this.syncToMemory(function() {
+              console.info('SYNC QUERY 11');
               this.set('data', this.zeroValue);
+              this.__queryIsChanging = false;
             });
           }
 


### PR DESCRIPTION
Should resolve https://github.com/firebase/polymerfire/issues/100, which is a pretty serious issue.

Basically, when firebase-query path changes, the data is reset twice (`this.data = this.zeroValue`) -
- The first time here, https://github.com/firebase/polymerfire/blob/master/firebase-query.html#L287
- And the second time there,  https://github.com/firebase/polymerfire/blob/master/firebase-database-behavior.html#L95

The problem is that it happens that data is populated (via `__onFirebaseChildAdded`) before the second reset - which then clear the data Array... 

Test case : 
```html
<dom-module id="test-app">
  <template>
    <style>
    :host {
      display: block;
    }
    </style>
    <h1>Test App</h1>
    <firebase-app  api-key="AIzaSyBzKhxNa2k9pA3m9_Ji3POFAKyGGFnyshI" auth-domain="note-app-firebase-3a483.firebaseapp.com" database-url="https://note-app-firebase-3a483.firebaseio.com"></firebase-app>
    <firebase-query id="query" log data="{{data}}" path="[[path]]"></firebase-query>
    <firebase-query  log data="{{dataStatic}}" path="/list"></firebase-query>
    <paper-button on-tap="togglePath" raised>toggle path</paper-button>
    <h2>Static path</h2>
    <ul>
      <template is="dom-repeat" items="[[dataStatic]]">
        <li>[[item.val]]</li>
      </template>
    </ul>
    <h2>Dynamic path ([[path]])</h2>
    <p>data is not populated when the path is set back to /list</p>
    <ul>
      <template is="dom-repeat" items="[[data]]">
        <li>[[item.val]]</li>
      </template>
    </ul>
  </template>
  <script>
  Polymer({
    is: 'test-app',

    properties: {

      path: {
        type: String,
        value: '/list'
      },

      dataStatic: Array,

      data: Array
    },

    attached:function() {
      firebase.database().ref('/list').set([{val: 'first'},{val: 'second'}], function(e){console.info(e);});
    },

    togglePath: function() {
      return this.path = this.path === '/list' ? '/emptyList' : '/list';
    }
  });
  </script>
</dom-module>

```

