### PR TITLE
Added `storage-bucket` and `messaging-sender-id` to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@ workflows.
 Example Usage:
 
 ```html
-<firebase-app auth-domain="polymerfire-test.firebaseapp.com"
+<firebase-app
+  auth-domain="polymerfire-test.firebaseapp.com"
   database-url="https://polymerfire-test.firebaseio.com/"
-  api-key="AIzaSyDTP-eiQezleFsV2WddFBAhF_WEzx_8v_g">
+  api-key="AIzaSyDTP-eiQezleFsV2WddFBAhF_WEzx_8v_g"
+  storage-bucket="polymerfire-test.appspot.com"
+  messaging-sender-id="544817973908">
 </firebase-app>
 <firebase-auth id="auth" user="{{user}}" provider="google" on-error="handleError">
 </firebase-auth>


### PR DESCRIPTION
Added `storage-bucket` and `messaging-sender-id` to the `README.md` to make sure people know what they are called. Issue reported on the Google Group [here](https://groups.google.com/forum/#!msg/firebase-talk/FlIIssiiKzs/qalBO7xADAAJ).