### PR TITLE
Speed up loading the initial data, by using the 'value' callback.

### DIFF
--- a/firebase-query.html
+++ b/firebase-query.html
@@ -280,18 +280,31 @@ Polymer({
 
         __queryChanged: function(query, oldQuery) {
           if (oldQuery) {
+            oldQuery.off('value', this.__onFirebaseValue, this);
             oldQuery.off('child_added', this.__onFirebaseChildAdded, this);
             oldQuery.off('child_removed', this.__onFirebaseChildRemoved, this);
             oldQuery.off('child_changed', this.__onFirebaseChildChanged, this);
             oldQuery.off('child_moved', this.__onFirebaseChildMoved, this);
 
             this.syncToMemory(function() {
+              this.__map = {};
               this.set('data', this.zeroValue);
             });
           }
 
           if (query) {
-            query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
+            /* The 'value' event doesn't order the data, so we have to
+             * revert to the slow path if ordering is requested
+             */
+            if (this.orderByChild || this.orderByValue) {
+              query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
+            } else {
+              /* Don't use query.once() as we need to be able to cancel
+               * the callback if the query changes
+               */
+              query.on('value', this.__onFirebaseValue, this.__onError, this);
+            }
+
             query.on('child_removed', this.__onFirebaseChildRemoved, this.__onError, this);
             query.on('child_changed', this.__onFirebaseChildChanged, this.__onError, this);
             query.on('child_moved', this.__onFirebaseChildMoved, this.__onError, this);
@@ -309,17 +322,45 @@ Polymer({
           return -1;
         },
 
+        __onFirebaseValue: function(snapshot) {
+          this.query.off('value', this.__onFirebaseValue, this);
+
+          if (snapshot.hasChildren()) {
+            var items = snapshot.val();
+            var keys = Object.keys(items);
+            var data = [];
+
+            for (var i = 0, len = keys.length; i < len; i++) {
+              var key = keys[i];
+              var value = this.__valueWithKey(key, items[key]);
+
+              this._log('Firebase value added:', key, value);
+
+              this.__map[key] = value;
+              data.push(value);
+            }
+
+            this.set('data', data);
+          }
+
+          /* Now start listening for changes */
+          this.query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
+        },
+
         __onFirebaseChildAdded: function(snapshot, previousChildKey) {
           var key = snapshot.key;
-          var value = snapshot.val();
-          var previousChildIndex = this.__indexFromKey(previousChildKey);
 
-          this._log('Firebase child_added:', key, value);
+          if (!this.__map[key]) {
+            var value = snapshot.val();
+            var previousChildIndex = this.__indexFromKey(previousChildKey);
 
-          value = this.__snapshotToValue(snapshot);
+            this._log('Firebase child_added:', key, value);
 
-          this.__map[key] = value;
-          this.splice('data', previousChildIndex + 1, 0, value);
+            value = this.__snapshotToValue(snapshot);
+
+            this.__map[key] = value;
+            this.splice('data', previousChildIndex + 1, 0, value);
+          }
         },
 
         __onFirebaseChildRemoved: function(snapshot) {
@@ -394,10 +435,7 @@ Polymer({
           }
         },
 
-        __snapshotToValue: function(snapshot) {
-          var key = snapshot.key;
-          var value = snapshot.val();
-
+        __valueWithKey: function(key, value) {
           var leaf = typeof value !== 'object';
 
           if (leaf) {
@@ -406,6 +444,13 @@ Polymer({
             value.$key = key;
           }
           return value;
+        },
+
+        __snapshotToValue: function(snapshot) {
+          var key = snapshot.key;
+          var value = snapshot.val();
+
+          return this.__valueWithKey(key, value);
         }
       });
     })();

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -319,11 +319,12 @@ Polymer({
           this.query.off('value', this.__onFirebaseValue, this);
 
           if (snapshot.hasChildren()) {
+            var data = [];
             snapshot.forEach(function(childSnapshot) {
               var key = childSnapshot.key;
               var value = this.__valueWithKey(key, childSnapshot.val())
               this.__map[key] = value;
-              this.push('data', value)
+              data.push(value)
             }.bind(this))
 
             this.set('data', data);

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -293,18 +293,11 @@ Polymer({
           }
 
           if (query) {
-            /* The 'value' event doesn't order the data, so we have to
-             * revert to the slow path if ordering is requested
-             */
-            if (this.orderByChild || this.orderByValue) {
-              query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
-            } else {
-              /* Don't use query.once() as we need to be able to cancel
-               * the callback if the query changes
-               */
-              query.on('value', this.__onFirebaseValue, this.__onError, this);
-            }
 
+            /* Don't use query.once() as we need to be able to cancel
+              * the callback if the query changes
+              */
+            query.on('value', this.__onFirebaseValue, this.__onError, this);
             query.on('child_removed', this.__onFirebaseChildRemoved, this.__onError, this);
             query.on('child_changed', this.__onFirebaseChildChanged, this.__onError, this);
             query.on('child_moved', this.__onFirebaseChildMoved, this.__onError, this);
@@ -326,19 +319,12 @@ Polymer({
           this.query.off('value', this.__onFirebaseValue, this);
 
           if (snapshot.hasChildren()) {
-            var items = snapshot.val();
-            var keys = Object.keys(items);
-            var data = [];
-
-            for (var i = 0, len = keys.length; i < len; i++) {
-              var key = keys[i];
-              var value = this.__valueWithKey(key, items[key]);
-
-              this._log('Firebase value added:', key, value);
-
+            snapshot.forEach(function(childSnapshot) {
+              var key = childSnapshot.key;
+              var value = this.__valueWithKey(key, childSnapshot.val())
               this.__map[key] = value;
-              data.push(value);
-            }
+              this.push('data', value)
+            }.bind(this))
 
             this.set('data', data);
           }

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -293,11 +293,16 @@ Polymer({
           }
 
           if (query) {
+            /* We want the value callback to batch load the initial data,
+             * then let child_added take over for subsequent changes.
+             */
+            this.__initialLoadDone = false;
 
             /* Don't use query.once() as we need to be able to cancel
               * the callback if the query changes
               */
             query.on('value', this.__onFirebaseValue, this.__onError, this);
+            query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
             query.on('child_removed', this.__onFirebaseChildRemoved, this.__onError, this);
             query.on('child_changed', this.__onFirebaseChildChanged, this.__onError, this);
             query.on('child_moved', this.__onFirebaseChildMoved, this.__onError, this);
@@ -316,8 +321,6 @@ Polymer({
         },
 
         __onFirebaseValue: function(snapshot) {
-          this.query.off('value', this.__onFirebaseValue, this);
-
           if (snapshot.hasChildren()) {
             var data = [];
             snapshot.forEach(function(childSnapshot) {
@@ -330,14 +333,15 @@ Polymer({
             this.set('data', data);
           }
 
-          /* Now start listening for changes */
-          this.query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
+          /* Now let child_added deal with subsequent changes */
+          this.query.off('value', this.__onFirebaseValue, this);
+          this.__initialLoadDone = true;
         },
 
         __onFirebaseChildAdded: function(snapshot, previousChildKey) {
           var key = snapshot.key;
 
-          if (!this.__map[key]) {
+          if (this.__initialLoadDone) {
             var value = snapshot.val();
             var previousChildIndex = this.__indexFromKey(previousChildKey);
 


### PR DESCRIPTION
When 'value' has finished, then start listening for 'child_added'; in
the 'child_added' callback, ignore any additions that we already have.

All polymerfire tests pass.

Fixes #212 