### PR TITLE
Fix data property name in docs

### DIFF
--- a/firebase-messaging.html
+++ b/firebase-messaging.html
@@ -39,7 +39,7 @@ you can actually send push messsages:
 
 ```html
 <firebase-messaging token="{{token}}"></firebase-messaging>
-<firebase-document path="/users/[[user.uid]]/token" value="[[token]]"></firebase-document>
+<firebase-document path="/users/[[user.uid]]/token" data="[[token]]"></firebase-document>
 ```
 
 You'll also need a [Web App Manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest)


### PR DESCRIPTION
<firebase-document> uses the property name "data", not "value"