### PR TITLE
Depend on Firebase SDK ^4.1.1, removing loading caveat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,27 +14,10 @@ thing! https://github.com/PolymerLabs/tedium/issues
 
 [![Build status](https://travis-ci.org/firebase/polymerfire.svg?branch=master)](https://travis-ci.org/firebase/polymerfire)
 
-## Loading Polymerfire
-
-The Firebase SDK can be loaded modularly (e.g. I can only load Auth and Database but not Storage or Messaging), but **all features must be loaded before the SDK is initialized** (lazy loading is not supported). A good way to handle this is to import `<firebase-app>` as well as any scripts you need for specific features:
-
-```html
-<link rel="import" href="bower_components/polymerfire/firebase-app.html">
-<link rel="import" href="bower_components/polymerfire/firebase-auth-script.html">
-<link rel="import" href="bower_components/polymerfire/firebase-database-script.html">
-<link rel="import" href="bower_components/polymerfire/firebase-storage-script.html">
-<link rel="import" href="bower_components/polymerfire/firebase-messaging-script.html">
-
-<firebase-app
-  database-url="..." storage-bucket="..." api-key="..." messaging-sender-id="..." auth-domain="...">
-</firebase-app>
-```
-
 ## &lt;firebase-app&gt;
 
 The firebase-app element is used for initializing and configuring your
 connection to firebase.
-
 
 
 ## &lt;firebase-auth&gt;

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "polymer": "polymer/polymer#1.9 - 2",
-    "firebase": ">= 3.5.1 < 4.0",
+    "firebase": "^4.1.1",
     "app-storage": "PolymerElements/app-storage#1 - 2"
   },
   "devDependencies": {
@@ -31,7 +31,7 @@
     "1.x": {
       "dependencies": {
         "polymer": "Polymer/polymer#^1.9",
-        "firebase": ">= 3.5.1 < 4.0",
+        "firebase": "^4.1.1",
         "app-storage": "polymerelements/app-storage#^0.9.0"
       },
       "devDependencies": {


### PR DESCRIPTION
Since the newly-shipped 4.1 version of the Firebase JS SDK now supports lazy loading, we no longer need to provide guidance about how to load Polymerfire. It should "just work"!

/cc @jshcrowthe 