### PR TITLE
added exists attribute, reflecting whether we have data at a given path

### DIFF
--- a/firebase-database-behavior.html
+++ b/firebase-database-behavior.html
@@ -14,6 +14,12 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
   (function() {
     'use strict';
 
+    /**
+     * the element is notified that the path does not hold any data (fired by firebase-document or firebase query)
+     *
+     * @event empty-result
+     */
+
     /** @polymerBehavior Polymer.FirebaseDatabaseBehavior */
     Polymer.FirebaseDatabaseBehaviorImpl = {
       properties: {
@@ -46,7 +52,20 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
         disabled: {
           type: Boolean,
           value: false
-        }
+        },
+
+        /**
+         * `exists` is set to `true` when the data actually exists for the specified path; `false` otherwise. 
+         * When we are unable to determine whether data exists or not (e.g. first round trip to the server not yet performed) the value is `null`
+         */
+        exists: {
+          type: Boolean,
+          notify: true,
+          value: null, 
+          readOnly: true,
+          reflectToAttribute: true
+        },
+
       },
 
       observers: [
@@ -95,6 +114,8 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
       },
 
       __pathChanged: function(path, oldPath) {
+        this._setExists(null);
+
         if (!this.disabled && !this.valueIsEmpty(this.data)) {
           this.syncToMemory(function() {
             this.data = this.zeroValue;

--- a/firebase-database-behavior.html
+++ b/firebase-database-behavior.html
@@ -14,12 +14,6 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
   (function() {
     'use strict';
 
-    /**
-     * the element is notified that the path does not hold any data (fired by firebase-document or firebase query)
-     *
-     * @event empty-result
-     */
-
     /** @polymerBehavior Polymer.FirebaseDatabaseBehavior */
     Polymer.FirebaseDatabaseBehaviorImpl = {
       properties: {
@@ -55,8 +49,11 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
         },
 
         /**
-         * `exists` is set to `true` when the data actually exists for the specified path; `false` otherwise. 
-         * When we are unable to determine whether data exists or not (e.g. first round trip to the server not yet performed) the value is `null`
+         * `exists` is set to `true` when the data actually exists for the 
+         * specified path; `false` otherwise. 
+         * When we are unable to determine whether data exists or not 
+         * (e.g. first round trip to the server not yet performed) the value 
+         * is `null`
          */
         exists: {
           type: Boolean,

--- a/firebase-document.html
+++ b/firebase-document.html
@@ -160,11 +160,13 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
 
     __onFirebaseValue: function(snapshot) {
       var value = snapshot.val();
+      var exists = true;
 
       if (value == null) {
         value = this.zeroValue;
         this.__needSetData = true;
-      }
+         exists = false;
+      } 
 
       if (!this.isNew) {
         this.async(function() {
@@ -188,6 +190,10 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
               }
             }
           });
+          this._setExists(exists);
+          if(!exists) {
+            this.fire('empty-result');
+          }
         });
       }
     }

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -354,7 +354,6 @@ Polymer({
           var key = snapshot.key;
 
           if (this.__initialLoadDone) {
-                        
             var value = snapshot.val();
             var previousChildIndex = this.__indexFromKey(previousChildKey);
 
@@ -363,8 +362,8 @@ Polymer({
             value = this.__snapshotToValue(snapshot);
 
             this.__map[key] = value;
-            this._setExists(true);
             this.splice('data', previousChildIndex + 1, 0, value);
+            this._setExists(true);
           }
         },
 
@@ -382,7 +381,6 @@ Polymer({
               });
               if (this.data.length === 0) {
                 this._setExists(false);
-                this.fire('empty-result');
               }
             });
           }

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -340,6 +340,7 @@ Polymer({
             }.bind(this))
 
             this.set('data', data);
+            this._setExists(true);
           }
 
           const query = this.query

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -287,6 +287,7 @@ Polymer({
 
             this.syncToMemory(function() {
               this.set('data', this.zeroValue);
+              this._setExists(null);
             });
           }
 
@@ -298,7 +299,8 @@ Polymer({
               query.off('child_moved', this.__onFirebaseChildMoved, this);
             }
 
-            this._onOnce = true;            
+            this._setExists(null);           
+            this._onOnce = true; 
             query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
             query.on('child_removed', this.__onFirebaseChildRemoved, this.__onError, this);
             query.on('child_changed', this.__onFirebaseChildChanged, this.__onError, this);
@@ -327,6 +329,7 @@ Polymer({
           value = this.__snapshotToValue(snapshot);
 
           this.__map[key] = value;
+          this._setExists(true);
           this.splice('data', previousChildIndex + 1, 0, value);
         },
 
@@ -342,6 +345,10 @@ Polymer({
               this.syncToMemory(function() {
                 this.splice('data', this.__indexFromKey(key), 1);
               });
+              if (this.data.length === 0) {
+                this._setExists(false);
+                this.fire('empty-result');
+              }
             });
           }
         },

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -300,7 +300,8 @@ Polymer({
               query.off('child_changed', this.__onFirebaseChildChanged, this);
               query.off('child_moved', this.__onFirebaseChildMoved, this);
             }
-         
+            
+            this._setExists(null);   
             this._onOnce = true;            
 
             /* We want the value callback to batch load the initial data,
@@ -312,8 +313,7 @@ Polymer({
               * the callback if the query changes
               */
             query.on('value', this.__onFirebaseValue, this.__onError, this);
-            this._setExists(null);         
-
+           
             query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
             query.on('child_removed', this.__onFirebaseChildRemoved, this.__onError, this);
             query.on('child_changed', this.__onFirebaseChildChanged, this.__onError, this);

--- a/test/firebase-document.html
+++ b/test/firebase-document.html
@@ -65,6 +65,59 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
           });
         }
       });
+
+     function pushFirebaseValue(path, value) {
+       return firebase.app('test').database().ref(path).push(value);
+      }
+
+      function clearFirebaseValue(path) {
+        return firebase.app('test').database().ref(path).set(null);
+      }
+
+      var makeObject;
+      var root;
+
+      setup(function() {
+        var objectId = 0;
+        makeObject = function(value) {
+          return {
+            val: value || objectId++
+          };
+        };
+
+        return pushFirebaseValue('/test', { ignore: 'me' }).then(function(snapshot) {
+          root = '/test/' + snapshot.key;
+        });
+      });
+
+      suite('exists attribute', function() {
+         var query;
+
+        setup(function() {
+          query = fixture('BasicStorage');
+          query.path = root + '/list';
+          return query.transactionsComplete;
+        });
+
+        test('exists is null when we change the path', function() {
+          query.path = '/myNewPath';
+          expect(query.exists).to.be.equal(null);
+        });
+
+        test('exists is true when we have data false when we remove it.', function() {
+          var object = makeObject();
+
+          return pushFirebaseValue(query.path, object).then(function() {
+            expect(query.exists).to.be.equal(true);
+          }).then(function(){
+            clearFirebaseValue(query.path);
+          }).then(function() {
+            expect(query.exists).to.be.equal(false);
+          });
+        });
+        
+      });
+
     });
   </script>
 </body>

--- a/test/firebase-query.html
+++ b/test/firebase-query.html
@@ -176,6 +176,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
           var object = makeObject();
 
           return pushFirebaseValue(query.path, object).then(function() {
+            expect(query.exists).to.be.equal(true);
             expect(query.data.length).to.be.equal(1);
             expect(query.data[0]).to.be.ok;
             expect(query.data[0].val).to.be.equal(object.val);
@@ -239,6 +240,22 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
                 query.path + '/' + query.data[0].$key + '/foo', null);
           }).then(function() {
             expect(query.data[0].foo).to.be.eql(undefined);
+          });
+        });
+
+        test('exists is null when template is stamped', function() {
+          expect(query.exists).to.be.equal(null);
+        })
+
+        test('exists is true when we have data false when we remove it.', function() {
+          var object = makeObject();
+
+          return pushFirebaseValue(query.path, object).then(function() {
+            expect(query.exists).to.be.equal(true);
+          }).then(function(){
+            clearFirebaseValue(query.path);
+          }).then(function() {
+            expect(query.exists).to.be.equal(false);
           });
         });
       });


### PR DESCRIPTION
Replace and close https://github.com/firebase/polymerfire/pull/177. 
Follows #33 discussion. 

An "empty-result" event is fired by firebase-document or firebase-query to notify that the path does not hold any data.