### PR TITLE
Fix child-moved handler

### DIFF
--- a/firebase-query.html
+++ b/firebase-query.html
@@ -382,7 +382,7 @@ Polymer({
         __onFirebaseChildMoved: function(snapshot, previousChildKey) {
           var key = snapshot.key;
           var value = this.__map[key];
-          var targetIndex = previousChildKey ? this.__indexFromKey(previousChildKey) : 0;
+          var targetIndex = previousChildKey ? this.__indexFromKey(previousChildKey) + 1 : 0;
 
           this._log('Firebase child_moved:', key, value,
               'to index', targetIndex);


### PR DESCRIPTION
Correct the the `__onFirebaseChildMoved` function to insert the value at the correct index
Fixes #240 