### PR TITLE
Fix __onFirebaseChildChanged handler

### DIFF
--- a/firebase-query.html
+++ b/firebase-query.html
@@ -368,7 +368,7 @@ Polymer({
                   }
                   for (var property in prev) {
                     if(!value.hasOwnProperty(property)) {
-                      this.set(['data', index, property], undefined);
+                      this.set(['data', index, property], null);
                     }
                   }
                 } else {


### PR DESCRIPTION
Set removed properties to `null` instead of `undefined` so the `data` property correctly fires change notifications for them.

Fixes #248 