### PR TITLE
from polymer to Polymer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "/test/"
   ],
   "dependencies": {
-    "polymer": "polymer/polymer#1.9 - 2",
+    "polymer": "Polymer/polymer#1.9 - 2",
     "firebase": "^4.1.1",
     "app-storage": "PolymerElements/app-storage#1 - 2"
   },
@@ -32,7 +32,7 @@
       "dependencies": {
         "polymer": "Polymer/polymer#^1.9",
         "firebase": "^4.1.1",
-        "app-storage": "polymerelements/app-storage#^0.9.0"
+        "app-storage": "PolymerElements/app-storage#^0.9.0"
       },
       "devDependencies": {
         "iron-component-page": "PolymerElements/iron-component-page#^1.0",


### PR DESCRIPTION
This pull requests want to make this Polymer element consistent with the majority of other Polymer elements. The uppercase version "Polymer" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.