### PR TITLE
fix firebase query returns 2 sets for #263

### DIFF
--- a/firebase-query.html
+++ b/firebase-query.html
@@ -353,7 +353,8 @@ Polymer({
         __onFirebaseChildAdded: function(snapshot, previousChildKey) {
           var key = snapshot.key;
 
-          if (this.__map[key]) return
+          // check if the key-value pair already exists
+          if (this.__indexFromKey(key) < 0) return
 
           var value = snapshot.val();
           var previousChildIndex = this.__indexFromKey(previousChildKey);
@@ -377,7 +378,11 @@ Polymer({
             this.__map[key] = null;
             this.async(function() {
               this.syncToMemory(function() {
-                this.splice('data', this.__indexFromKey(key), 1);
+                // this only catches already deleted keys (which will return -1)
+                // at least it will not delete the last element from the array (this.splice('data', -1, 1))
+                if (this.__indexFromKey(key) >= 0) {
+                  this.splice('data', this.__indexFromKey(key), 1);
+                }
               });
             });
           }

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -292,47 +292,51 @@ Polymer({
             });
           }
 
-          query.once('value').then(function(snapshot) {
-            if (snapshot.hasChildren()) {
-              var data = [];
-              snapshot.forEach(function(childSnapshot) {
-                var key = childSnapshot.key;
-                var value = this.__valueWithKey(key, childSnapshot.val())
-                this.__map[key] = value;
-                data.push(value)
-              }.bind(this))
+          // this allows us to just call the addition of event listeners only once.
+          // __queryChanged is being called thrice when firebase-query is created
+          // 1 - 2. query property computed (null, undefined)
+          // 3. when attached is called (this.query, this.query) -> this is where we add stuff
 
-              this.set('data', data);
+          // hopefully if reference changed, this still fire
+
+          if (query && oldQuery) {
+            if(this._onOnce){ // remove handlers before adding again. Otherwise we get data multiplying
+              query.off('child_added', this.__onFirebaseChildAdded, this);
+              query.off('child_removed', this.__onFirebaseChildRemoved, this);
+              query.off('child_changed', this.__onFirebaseChildChanged, this);
+              query.off('child_moved', this.__onFirebaseChildMoved, this);
             }
 
-            query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
-            query.on('child_removed', this.__onFirebaseChildRemoved, this.__onError, this);
-            query.on('child_changed', this.__onFirebaseChildChanged, this.__onError, this);
-            query.on('child_moved', this.__onFirebaseChildMoved, this.__onError, this);
-          }.bind(this))
+            this._onOnce = true;
 
+            // does the on-value first
+            query.once('value')
+              .then(function(snapshot) {
+                if (snapshot.hasChildren()) {
+                  var data = [];
+                  snapshot.forEach(function(childSnapshot) {
+                    var key = childSnapshot.key;
+                    var value = this.__valueWithKey(key, childSnapshot.val())
 
-          // if (query) {
-          //   if(this._onOnce){ // remove handlers before adding again. Otherwise we get data multiplying
-          //     query.off('child_added', this.__onFirebaseChildAdded, this);
-          //     query.off('child_removed', this.__onFirebaseChildRemoved, this);
-          //     query.off('child_changed', this.__onFirebaseChildChanged, this);
-          //     query.off('child_moved', this.__onFirebaseChildMoved, this);
-          //   }
+                    this.__map[key] = value;
+                    data.push(value)
+                  }.bind(this))
 
-          //   this._onOnce = true;
+                  this.set('data', data);
+                }
+              }.bind(this))
 
-          //   /* We want the value callback to batch load the initial data,
-          //    * then let child_added take over for subsequent changes.
-          //    */
-          //   this.__initialLoadDone = false;
+              // catches the error above but still sets the listeners below
+              .catch(this.__onError.bind(this))
 
-          //   /* Don't use query.once() as we need to be able to cancel
-          //     * the callback if the query changes
-          //     */
-          //   query.on('value', this.__onFirebaseValue, this.__onError, this);
-
-          // }
+              // here comes the per child event listeners
+              .then(function() {
+                query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
+                query.on('child_removed', this.__onFirebaseChildRemoved, this.__onError, this);
+                query.on('child_changed', this.__onFirebaseChildChanged, this.__onError, this);
+                query.on('child_moved', this.__onFirebaseChildMoved, this.__onError, this);
+              }.bind(this))
+          }
         },
 
         __indexFromKey: function(key) {
@@ -346,18 +350,11 @@ Polymer({
           return -1;
         },
 
-        // __onFirebaseValue: function(snapshot) {
-
-
-        //   /* Now let child_added deal with subsequent changes */
-        //   // this.query.off('value', this.__onFirebaseValue, this);
-        //   // this.__initialLoadDone = true;
-        // },
-
         __onFirebaseChildAdded: function(snapshot, previousChildKey) {
           var key = snapshot.key;
 
-          // if (this.__initialLoadDone) {
+          if (this.__map[key]) return
+
           var value = snapshot.val();
           var previousChildIndex = this.__indexFromKey(previousChildKey);
 
@@ -367,10 +364,10 @@ Polymer({
 
           this.__map[key] = value;
           this.splice('data', previousChildIndex + 1, 0, value);
-          // }
         },
 
         __onFirebaseChildRemoved: function(snapshot) {
+
           var key = snapshot.key;
           var value = this.__map[key];
 

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -292,30 +292,47 @@ Polymer({
             });
           }
 
-          if (query) {
-            if(this._onOnce){ // remove handlers before adding again. Otherwise we get data multiplying
-              query.off('child_added', this.__onFirebaseChildAdded, this);
-              query.off('child_removed', this.__onFirebaseChildRemoved, this);
-              query.off('child_changed', this.__onFirebaseChildChanged, this);
-              query.off('child_moved', this.__onFirebaseChildMoved, this);
+          query.once('value').then(function(snapshot) {
+            if (snapshot.hasChildren()) {
+              var data = [];
+              snapshot.forEach(function(childSnapshot) {
+                var key = childSnapshot.key;
+                var value = this.__valueWithKey(key, childSnapshot.val())
+                this.__map[key] = value;
+                data.push(value)
+              }.bind(this))
+
+              this.set('data', data);
             }
 
-            this._onOnce = true;            
-
-            /* We want the value callback to batch load the initial data,
-             * then let child_added take over for subsequent changes.
-             */
-            this.__initialLoadDone = false;
-
-            /* Don't use query.once() as we need to be able to cancel
-              * the callback if the query changes
-              */
-            query.on('value', this.__onFirebaseValue, this.__onError, this);
             query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
             query.on('child_removed', this.__onFirebaseChildRemoved, this.__onError, this);
             query.on('child_changed', this.__onFirebaseChildChanged, this.__onError, this);
             query.on('child_moved', this.__onFirebaseChildMoved, this.__onError, this);
-          }
+          }.bind(this))
+
+
+          // if (query) {
+          //   if(this._onOnce){ // remove handlers before adding again. Otherwise we get data multiplying
+          //     query.off('child_added', this.__onFirebaseChildAdded, this);
+          //     query.off('child_removed', this.__onFirebaseChildRemoved, this);
+          //     query.off('child_changed', this.__onFirebaseChildChanged, this);
+          //     query.off('child_moved', this.__onFirebaseChildMoved, this);
+          //   }
+
+          //   this._onOnce = true;
+
+          //   /* We want the value callback to batch load the initial data,
+          //    * then let child_added take over for subsequent changes.
+          //    */
+          //   this.__initialLoadDone = false;
+
+          //   /* Don't use query.once() as we need to be able to cancel
+          //     * the callback if the query changes
+          //     */
+          //   query.on('value', this.__onFirebaseValue, this.__onError, this);
+
+          // }
         },
 
         __indexFromKey: function(key) {
@@ -329,38 +346,28 @@ Polymer({
           return -1;
         },
 
-        __onFirebaseValue: function(snapshot) {
-          if (snapshot.hasChildren()) {
-            var data = [];
-            snapshot.forEach(function(childSnapshot) {
-              var key = childSnapshot.key;
-              var value = this.__valueWithKey(key, childSnapshot.val())
-              this.__map[key] = value;
-              data.push(value)
-            }.bind(this))
+        // __onFirebaseValue: function(snapshot) {
 
-            this.set('data', data);
-          }
 
-          /* Now let child_added deal with subsequent changes */
-          this.query.off('value', this.__onFirebaseValue, this);
-          this.__initialLoadDone = true;
-        },
+        //   /* Now let child_added deal with subsequent changes */
+        //   // this.query.off('value', this.__onFirebaseValue, this);
+        //   // this.__initialLoadDone = true;
+        // },
 
         __onFirebaseChildAdded: function(snapshot, previousChildKey) {
           var key = snapshot.key;
 
-          if (this.__initialLoadDone) {
-            var value = snapshot.val();
-            var previousChildIndex = this.__indexFromKey(previousChildKey);
+          // if (this.__initialLoadDone) {
+          var value = snapshot.val();
+          var previousChildIndex = this.__indexFromKey(previousChildKey);
 
-            this._log('Firebase child_added:', key, value);
+          this._log('Firebase child_added:', key, value);
 
-            value = this.__snapshotToValue(snapshot);
+          value = this.__snapshotToValue(snapshot);
 
-            this.__map[key] = value;
-            this.splice('data', previousChildIndex + 1, 0, value);
-          }
+          this.__map[key] = value;
+          this.splice('data', previousChildIndex + 1, 0, value);
+          // }
         },
 
         __onFirebaseChildRemoved: function(snapshot) {

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -295,11 +295,10 @@ Polymer({
           // this allows us to just call the addition of event listeners only once.
           // __queryChanged is being called thrice when firebase-query is created
           // 1 - 2. query property computed (null, undefined)
-          // 3. when attached is called (this.query, this.query) -> this is where we add stuff
+          // 3. when attached is called (this.query, this.query)
+          // need help to fix this so that this function is only called once
 
-          // hopefully if reference changed, this still fire
-
-          if (query && oldQuery) {
+          if (query) {
             if(this._onOnce){ // remove handlers before adding again. Otherwise we get data multiplying
               query.off('child_added', this.__onFirebaseChildAdded, this);
               query.off('child_removed', this.__onFirebaseChildRemoved, this);
@@ -308,34 +307,11 @@ Polymer({
             }
 
             this._onOnce = true;
+            this._query = query
 
             // does the on-value first
-            query.once('value')
-              .then(function(snapshot) {
-                if (snapshot.hasChildren()) {
-                  var data = [];
-                  snapshot.forEach(function(childSnapshot) {
-                    var key = childSnapshot.key;
-                    var value = this.__valueWithKey(key, childSnapshot.val())
-
-                    this.__map[key] = value;
-                    data.push(value)
-                  }.bind(this))
-
-                  this.set('data', data);
-                }
-              }.bind(this))
-
-              // catches the error above but still sets the listeners below
-              .catch(this.__onError.bind(this))
-
-              // here comes the per child event listeners
-              .then(function() {
-                query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
-                query.on('child_removed', this.__onFirebaseChildRemoved, this.__onError, this);
-                query.on('child_changed', this.__onFirebaseChildChanged, this.__onError, this);
-                query.on('child_moved', this.__onFirebaseChildMoved, this.__onError, this);
-              }.bind(this))
+            query.off('value', this.__onFirebaseValue, this)
+            query.on('value', this.__onFirebaseValue, this.__onError, this)
           }
         },
 
@@ -348,6 +324,36 @@ Polymer({
             }
           }
           return -1;
+        },
+
+        __onFirebaseValue: function(snapshot) {
+          if (snapshot.hasChildren()) {
+            var data = [];
+            snapshot.forEach(function(childSnapshot) {
+              var key = childSnapshot.key;
+              var value = this.__valueWithKey(key, childSnapshot.val())
+
+              this.__map[key] = value;
+              data.push(value)
+            }.bind(this))
+
+            this.set('data', data);
+          }
+
+          const query = this.query
+
+          query.off('value', this.__onFirebaseValue, this)
+
+          // ensures that all events are called once
+          query.off('child_added', this.__onFirebaseChildAdded, this);
+          query.off('child_removed', this.__onFirebaseChildRemoved, this);
+          query.off('child_changed', this.__onFirebaseChildChanged, this);
+          query.off('child_moved', this.__onFirebaseChildMoved, this);
+
+          query.on('child_added', this.__onFirebaseChildAdded, this.__onError, this);
+          query.on('child_removed', this.__onFirebaseChildRemoved, this.__onError, this);
+          query.on('child_changed', this.__onFirebaseChildChanged, this.__onError, this);
+          query.on('child_moved', this.__onFirebaseChildMoved, this.__onError, this);
         },
 
         __onFirebaseChildAdded: function(snapshot, previousChildKey) {

--- a/firebase-query.html
+++ b/firebase-query.html
@@ -354,7 +354,7 @@ Polymer({
           var key = snapshot.key;
 
           // check if the key-value pair already exists
-          if (this.__indexFromKey(key) < 0) return
+          if (this.__indexFromKey(key) >= 0) return
 
           var value = snapshot.val();
           var previousChildIndex = this.__indexFromKey(previousChildKey);


### PR DESCRIPTION
Fixing #263

I saw that the `__queryChanged` is being called thrice, making creation of event listeners called thrice. Currently wrapped them in a checker if both `query` and `oldQuery` exists with this idea

1. `__queryChanged` is called in the `attached` phased
2. `__queryChanged` is called when any time a new `query` is created on calculated in the `__computeQuery`

Can anyone give me some feedback on any bugs I missed?

Thanks
