### PR TITLE
Prepare Firestore functionality

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#1.9 - 2",
-    "firebase": "^4.1.1",
+    "firebase": "^4.5.0",
     "app-storage": "PolymerElements/app-storage#1 - 2"
   },
   "devDependencies": {
@@ -33,7 +33,7 @@
     "1.x": {
       "dependencies": {
         "polymer": "Polymer/polymer#^1.9",
-        "firebase": "^4.1.1",
+        "firebase": "^4.5.0",
         "app-storage": "PolymerElements/app-storage#^0.9.0"
       },
       "devDependencies": {

--- a/firebase-app.html
+++ b/firebase-app.html
@@ -96,6 +96,17 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
           },
 
           /**
+           * The Google Cloud Project ID for your project. You can find this
+           * in the Firebase Console under "Web Setup".
+           *
+           * For example: `polymerfire-test`
+           */
+          projectId: {
+            type: String,
+            value: null
+          },
+
+          /**
            * The Firebase app object constructed from the other fields of
            * this element.
            * @type {firebase.app.App}
@@ -103,16 +114,17 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
           app: {
             type: Object,
             notify: true,
-            computed: '__computeApp(name, apiKey, authDomain, databaseUrl, storageBucket, messagingSenderId)'
+            computed: '__computeApp(name, apiKey, authDomain, databaseUrl, storageBucket, messagingSenderId, projectId)'
           }
         },
 
-        __computeApp: function(name, apiKey, authDomain, databaseUrl, storageBucket, messagingSenderId) {
+        __computeApp: function(name, apiKey, authDomain, databaseUrl, storageBucket, messagingSenderId, projectId) {
           if (apiKey && authDomain && databaseUrl) {
             var init = [{
               apiKey: apiKey,
               authDomain: authDomain,
               databaseURL: databaseUrl,
+              projectId: projectId,
               storageBucket: storageBucket,
               messagingSenderId: messagingSenderId
             }];

--- a/firebase-app.html
+++ b/firebase-app.html
@@ -14,6 +14,7 @@ https://github.com/firebase/polymerfire/blob/master/LICENSE
 <link rel="import" href="firebase-auth-script.html">
 <link rel="import" href="firebase-storage-script.html">
 <link rel="import" href="firebase-messaging-script.html">
+<link rel="import" href="firebase-firestore-script.html">
 <dom-module id="firebase-app">
   <script>
     (function() {

--- a/firebase-firestore-script.html
+++ b/firebase-firestore-script.html
@@ -1,0 +1,1 @@
+<script src="../firebase/firebase-firestore.js"></script>


### PR DESCRIPTION
Preliminary changes necessary to enable Firestore functionalities.

For now this will only allow to initalize `<firebase-app>` with the necessary `projectId` in the options and loads the script necessary to use `firebase.firestore`.

How best to implement `firebase-firestore-query` and `firebase-firestore-document` remains to be seen.
And I guess the firestore persistance option should be added to `firebase-app`?