### PR TITLE
Fix `query` in FirestoreMixin.

### DIFF
--- a/firebase-firestore-mixin.html
+++ b/firebase-firestore-mixin.html
@@ -191,9 +191,8 @@ if (typeof Polymer === 'undefined') {
         this[name + 'Ref'] = ref;
         this[name + 'Ready'] = false;
 
-        const query = this.constructor.properties[name].query;
-        if (query) {
-          ref = query.call(this, ref, this);
+        if (config.query) {
+          ref = config.query.call(this, ref, this);
         }
 
         if (config.live) {


### PR DESCRIPTION
Fixes an issue with `query` parameter being read from the constructor of an element instead of collecting the correct one from the prototype chain in FirestoreMixin.

Fixes #296 