### PR TITLE
Fix an issue with initail binding in FirestoreMixin.

### DIFF
--- a/firebase-firestore-mixin.html
+++ b/firebase-firestore-mixin.html
@@ -162,9 +162,7 @@ if (typeof Polymer === 'undefined') {
         if (args.length) { args = ',' + args; }
         this._createMethodObserver(`_firestoreUpdateBinding('${type}','${name}'${args})`);
 
-        if (!config.props.length && !config.observes.length) {
-          this._firestoreUpdateBinding(type,name);
-        }
+        this._firestoreUpdateBinding(type,name);
       }
 
       _firestoreUpdateBinding(type, name) {


### PR DESCRIPTION
This change fixes an issue which occurs when observed/bound properties were defined prior to a call of `connectedCallback`. Since _firestoreUpdateBinding method handles null and undefined values correctly, the `if` statement can be safely removed.

Fixes #284 