### PR TITLE
Firestore

### DIFF
--- a/firebase-firestore-mixin.html
+++ b/firebase-firestore-mixin.html
@@ -169,10 +169,11 @@ if (typeof Polymer === 'undefined') {
 
         this._firestoreProps = {};
         this._firestoreListeners = {};
-        this.db = this.constructor.db || firebase.firestore();
       }
 
       connectedCallback() {
+        super.connectedCallback();
+        this.db = this.constructor.db || firebase.firestore();
         if (this[CONNECTED_CALLBACK_TOKEN] !== true) {
           this[CONNECTED_CALLBACK_TOKEN] = true;
 
@@ -188,8 +189,6 @@ if (typeof Polymer === 'undefined') {
             }
           }
         }
-
-        super.connectedCallback();
       }
 
       _firestoreBind(name, options) {

--- a/firebase-firestore-mixin.html
+++ b/firebase-firestore-mixin.html
@@ -210,9 +210,9 @@ if (typeof Polymer === 'undefined') {
           const observer =
             `_firestoreUpdateBinding('${name}', ${args.join(',')})`
           this._createMethodObserver(observer);
+        } else {
+          this._firestoreUpdateBinding(name, ...args.map(x => this[x]));
         }
-
-        this._firestoreUpdateBinding(name, ...args.map(x => this[x]));
       }
 
       _firestoreUpdateBinding(name, ...args) {


### PR DESCRIPTION
Fixes #326
Updates #279 as per the mixin format

- Prevents race conditions on setting up the DB.
- Prevents multi-splicing on `live` data updating to collections bound with more than one template variable.